### PR TITLE
Updated DB management to remove query print statement

### DIFF
--- a/db_management.py
+++ b/db_management.py
@@ -47,7 +47,6 @@ class DatabaseHandler:
             else:
                 cursor.execute(query)
             self.connection.commit()
-            print('execute query reached')
             return True
         except Exception as e:
             print(f"Error executing query: {e}")
@@ -186,4 +185,3 @@ class StoryManager(DatabaseHandler):
             return result
         else:
             return None
-


### PR DESCRIPTION
updated db_management so does not print execute query line after each DB query, as was cluttering our RUN_THIS_demo.py results